### PR TITLE
Upgrade Mockito to 2.20.1 for Java 11.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.3.0</version>
+      <version>2.20.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/com/google/enterprise/cloudsearch/fs/MockFile.java
+++ b/src/test/java/com/google/enterprise/cloudsearch/fs/MockFile.java
@@ -32,7 +32,6 @@ import java.nio.file.attribute.AclFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;


### PR DESCRIPTION
Other changes:
* Fix lint error (unused import).

Change-Id: Ibd17176da46981a465320ba0ecfaf5699f960194
(cherry picked from commit 1f883e253d1b014601403e8bbe97c1c6a2d1a37b)