### PR TITLE
Don't create ACL objects when defaultAcl mode is OVERRIDE

### DIFF
--- a/src/main/java/com/google/enterprise/cloudsearch/fs/FsRepository.java
+++ b/src/main/java/com/google/enterprise/cloudsearch/fs/FsRepository.java
@@ -762,6 +762,9 @@ public class FsRepository implements Repository {
         case DFS_SHARE_ACL:
         case SHARE_ACL:
           if (isAclModeOverride) {
+            log.log(Level.FINEST,
+                "Deleting ACL fragment item because default ACL mode is OVERRIDE: "
+                + docName);
             return ApiOperations.deleteItem(docName);
           } else {
             log.log(Level.FINEST, "Not re-indexing ACL fragment item");

--- a/src/test/java/com/google/enterprise/cloudsearch/fs/FsRepositoryTest.java
+++ b/src/test/java/com/google/enterprise/cloudsearch/fs/FsRepositoryTest.java
@@ -3312,6 +3312,24 @@ public class FsRepositoryTest {
   }
 
   @Test
+  public void getDoc_defaultAclOverride_noAclContainersCreated() throws Exception {
+    MockFile child = new MockFile("subdir", true)
+        .setAclView(EMPTY_ACLVIEW);
+    MockFile root = getShareRootDefaultAclViews("/")
+        .addChildren(child);
+    MultiRootMockFileDelegate delegate = new MultiRootMockFileDelegate(root);
+
+    when(mockRepositoryContext.getDefaultAclMode()).thenReturn(DefaultAclMode.OVERRIDE);
+
+    // This class tests FsRepository. The default ACL, when configured, is set in the
+    // connector template class, so we should just have a null ACL here.
+    verifyDocAcls(delegate, new Properties(), root.getPath(), delegate.newDocId(root),
+        null, Collections.emptyMap());
+    verifyDocAcls(delegate, new Properties(), root.getPath(), delegate.newDocId(child),
+        null, Collections.emptyMap());
+  }
+
+  @Test
   public void testGetDocRemoveUserDomain() throws Exception {
     AclFileAttributeView aclView = new AclView((user("domaintoremove\\joe")
         .type(ALLOW).perms(GenericPermission.GENERIC_READ).build()));

--- a/src/test/java/com/google/enterprise/cloudsearch/fs/FsRepositoryTest.java
+++ b/src/test/java/com/google/enterprise/cloudsearch/fs/FsRepositoryTest.java
@@ -3330,6 +3330,21 @@ public class FsRepositoryTest {
   }
 
   @Test
+  public void getDoc_defaultAclOverride_aclFragmentsDeleted() throws Exception {
+    MockFile root = getShareRootDefaultAclViews("/");
+    MultiRootMockFileDelegate delegate = new MultiRootMockFileDelegate(root);
+
+    when(mockRepositoryContext.getDefaultAclMode()).thenReturn(DefaultAclMode.OVERRIDE);
+
+    setConfig("/");
+    FsRepository fsRepository = new FsRepository(delegate);
+    fsRepository.init(mockRepositoryContext);
+
+    ApiOperation result = fsRepository.getDoc(new Item().setName("/file#shareAcl"));
+    assertEquals(ApiOperations.deleteItem("/file#shareAcl"), result);
+  }
+
+  @Test
   public void testGetDocRemoveUserDomain() throws Exception {
     AclFileAttributeView aclView = new AclView((user("domaintoremove\\joe")
         .type(ALLOW).perms(GenericPermission.GENERIC_READ).build()));


### PR DESCRIPTION
If defaultAcl.mode is set to OVERRIDE, don't create the virtual
containers for the file system ACLs. If the file system content has
been indexed previously, the ACL virtual containers will be deleted
when using OVERRIDE. The deletion will happen as the virtual
containers are polled for re-indexing, not immediately.

Bug: 141337637